### PR TITLE
Set non-asterisk version in META

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "perl"        : "6.*",
   "name"        : "Web::App::Ballet",
-  "version"     : "*",
+  "version"     : "0.1.0",
   "description" : "A Dancer-like interface to Web::App",
   "depends"     : 
   [ 


### PR DESCRIPTION
Having an version with an asterisk fails the ecosystem tests.

See one such failure in https://travis-ci.com/github/Raku/ecosystem/builds/204007135 and Raku/ecosystem#567 for some added context

I've set the version to 0.1.0 since this module seems to still be partially implemented, but that can be modified.